### PR TITLE
Update the regex expression to match 2 switchport access configuration

### DIFF
--- a/cisco_config_parser/parser_regex/ios_regex.py
+++ b/cisco_config_parser/parser_regex/ios_regex.py
@@ -38,7 +38,7 @@ IPV6_ADDRESS_REGEX = re.compile(r"ipv6\saddress\s(.*)", flags=re.MULTILINE)
 
 # L2 Interface
 SWITCHPORT_REGEX = re.compile(r"switchport\s(.*)", flags=re.MULTILINE)
-SWITCHPORT_ACCESS_REGEX = re.compile(r"switchport\smode\saccess", flags=re.MULTILINE)
+SWITCHPORT_ACCESS_REGEX = re.compile(r"switchport\s+(mode\saccess|access\svlan\s\d+)", flags=re.MULTILINE)
 SWITCHPORT_TRUNK_REGEX = re.compile(r"switchport\smode\strunk", flags=re.MULTILINE)
 SWITCHPORT_ACCESS_VLAN_REGEX = re.compile(r"switchport\saccess\svlan\s(.*)", flags=re.MULTILINE)
 SWITCHPORT_VOICE_VLAN_REGEX = re.compile(r"switchport\svoice\svlan\s(.*)", flags=re.MULTILINE)


### PR DESCRIPTION
Hello. 
I encounter the same issue. On Catalyst 9500 the "switchport mode access" is not mandatory so optionally applied by netadmins. On the NX-OS it is definitely not present, only "switchport access vlan XXX" is remained.
So replace the    
`SWITCHPORT_ACCESS_REGEX = re.compile(r"switchport\smode\saccess", flags=re.MULTILINE)`
by
`SWITCHPORT_ACCESS_REGEX = re.compile(r"switchport\s+(mode\saccess|access\svlan\s\d+)", flags=re.MULTILINE)switchport\s+`

I tested versus 
config = """
switchport mode access
switchport access vlan 10
switchport trunk
switchport mode trunk
switchport access vlan abc
switchport access vlan 123
"""

New regex match "switchport mode access" of course.
When "switchport mode access" removed, it matches also "switchport access vlan 10".
it permits to recognyze the access interfaces even if the switchport mode access is missing.

It is a fix for the issue #23  

Thanks